### PR TITLE
Add camera names + fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ uv sync
 After completing the python installation, install frontend dependencies:
 
 ```bash
-cd packages/lerobot-data-studio/frontend
+cd src/lerobot-data-studio/frontend
 npm install
 ```
 

--- a/src/lerobot_data_studio/backend/main.py
+++ b/src/lerobot_data_studio/backend/main.py
@@ -185,7 +185,10 @@ async def get_episode(
 
     video_paths = [dataset.meta.get_video_file_path(episode_id, key) for key in dataset.meta.video_keys]
     videos_info = [
-        VideoInfo(url=f"/api/videos/{repo_id}/{str(video_path)}", filename=video_path.parent.name)
+        VideoInfo(
+            url=f"/api/videos/{repo_id}/{str(video_path)}",
+            filename=f"{video_path.parent.parent.name} ({video_path.parent.name})",
+        )
         for video_path in video_paths
     ]
     tasks = dataset.meta.episodes[episode_id]["tasks"]


### PR DESCRIPTION
- Fixed a little typo in readme 
- Added camera names to the video windows. It's quite convenient for debugging camera names like static1, static2, wrist1, wrist2 etc. So you can check that camera names in different datasets follow same convention. 